### PR TITLE
Fixing metadata upload to s3

### DIFF
--- a/server.js
+++ b/server.js
@@ -286,7 +286,7 @@ app.post('*', function (req, res, next) {
 
   if (config.s3_bucket) {
     const metadata_upload_params = {
-      Body: metadata,
+      Body: JSON.stringify(metadata),
       Bucket: config.s3_bucket,
       ContentType: 'application/json',
       Key: key_base + '/metadata.json'


### PR DESCRIPTION
@milescrabill r? 

I'm getting the following on staging:

`{"message":{"message":"Expected params.Body to be a string, Buffer, Stream, Blob, or typed array object","code":"InvalidParameterType","time":"2018-10-10T18:2
5:42.235Z"}}    time_namelookup:  0.132919`

 So seems metadata needs to be a string instead a json. 